### PR TITLE
Issue #4: dashboard improvements (send/reconnect/sessions/tokens)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -527,7 +527,7 @@ function renderTokenHistoryGraph(history) {
     column.appendChild(label);
     tokenGraphEl.appendChild(column);
   });
-  if (tokenGraphLabel) tokenGraphLabel.textContent = 'Daily token total (last 5 London dates).';
+  if (tokenGraphLabel) tokenGraphLabel.textContent = 'Daily token total (last 5 local dates).';
 }
 
 

--- a/public/app.js
+++ b/public/app.js
@@ -315,9 +315,10 @@ async function refreshSessions() {
   // sessions.list shape: the Control UI uses sessions.list; response is { sessions: [...] }
   const resp = await request('sessions.list', { limit: 50, activeMinutes: 720 });
   const sessions = Array.isArray(resp?.sessions) ? resp.sessions : [];
+  const agentSessions = sessions.filter((s) => String(s?.key || '').startsWith('agent:'));
 
   sessionSelect.innerHTML = '';
-  for (const s of sessions) {
+  for (const s of agentSessions) {
     const key = (s?.key || '').trim();
     if (!key) continue;
     const kind = (s?.kind || '').trim();
@@ -330,9 +331,14 @@ async function refreshSessions() {
     sessionSelect.appendChild(opt);
   }
 
-  // keep selection if possible
-  if (selectedSessionKey) {
+  // keep selection if possible; otherwise fallback to first agent session
+  if (selectedSessionKey && agentSessions.some((s) => s?.key === selectedSessionKey)) {
     sessionSelect.value = selectedSessionKey;
+  } else if (agentSessions[0]?.key) {
+    await selectSession(agentSessions[0].key);
+    sessionSelect.value = agentSessions[0].key;
+  } else {
+    await selectSession('');
   }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -31,6 +31,7 @@ let pending = new Map();
 let lastSeq = null;
 
 let isReplying = false;
+let reconnectInProgress = false;
 let mood = 'neutral';
 let selectedSessionKey = localStorage.getItem('nova_webui_sessionKey') || '';
 let lastRunId = null;
@@ -172,6 +173,7 @@ function onChatEvent(payload) {
     if (currentAssistantMsgEl && text) currentAssistantMsgEl.textContent = text;
     setMood(inferMood(text));
     isReplying = false;
+    sendBtn.disabled = false;
     setChatStatus('idle', true, false);
     lastRunId = null;
     currentAssistantMsgEl = null;
@@ -182,6 +184,7 @@ function onChatEvent(payload) {
 
   if (payload.state === 'error' || payload.state === 'aborted') {
     isReplying = false;
+    sendBtn.disabled = false;
     setChatStatus('idle', true, false);
     lastRunId = null;
     if (currentAssistantMsgEl) currentAssistantMsgEl.textContent = payload.errorMessage || 'Error.';
@@ -288,6 +291,8 @@ async function connect() {
 
     ws.addEventListener('close', (ev) => {
       connected = false;
+      isReplying = false;
+      sendBtn.disabled = false;
       setChatStatus('disconnected', false, true);
       const code = ev?.code;
       const reason = ev?.reason;
@@ -300,6 +305,8 @@ async function connect() {
 
     ws.addEventListener('error', (ev) => {
       connected = false;
+      isReplying = false;
+      sendBtn.disabled = false;
       setStatus('ws error (see console)', false, true);
       setChatStatus('disconnected', false, true);
       console.error('ws error', ev);
@@ -382,8 +389,23 @@ async function selectSession(key) {
 
 async function send() {
   const msg = inputEl.value.trim();
-  if (!msg || isReplying || !connected || !selectedSessionKey) return;
+
+  if (!msg) {
+    setChatStatus('message required', false, true);
+    return;
+  }
+  if (isReplying) return;
+  if (!connected) {
+    setChatStatus('disconnected', false, true);
+    return;
+  }
+  if (!selectedSessionKey) {
+    setChatStatus('pick a session', false, true);
+    return;
+  }
+
   inputEl.value = '';
+  sendBtn.disabled = true;
 
   addMsg('user', msg);
   currentAssistantMsgEl = addMsg('assistant', '…');
@@ -412,6 +434,7 @@ async function send() {
     setChatStatus('error', false, true);
     setMood('serious');
     setMood(mood);
+    sendBtn.disabled = false;
   }
 }
 
@@ -641,11 +664,21 @@ function tick(t) {
 // events
 sendBtn.addEventListener('click', send);
 reconnectBtn.addEventListener('click', async () => {
+  if (reconnectInProgress) return;
+  reconnectInProgress = true;
+  reconnectBtn.disabled = true;
+  reconnectBtn.textContent = 'Reconnecting…';
+  setStatus('reconnecting…');
+
   try {
     await fetch('/api/reconnect', { method: 'POST' });
-  } catch {}
-  await connect();
-  await updateConnectionBadge();
+    await connect();
+    await updateConnectionBadge();
+  } finally {
+    reconnectInProgress = false;
+    reconnectBtn.disabled = false;
+    reconnectBtn.textContent = 'Reconnect';
+  }
 });
 clearBtn.addEventListener('click', () => {
   chatEl.innerHTML = '';

--- a/server.mjs
+++ b/server.mjs
@@ -106,8 +106,9 @@ const baseDir = path.dirname(new URL(import.meta.url).pathname);
 const DIST_DIR = path.join(baseDir, 'public');
 const TOKEN_HISTORY_PATH = path.join(HOME_DIR, '.openclaw', 'workspace', 'data', 'token_usage.json');
 
-function londonDateString() {
-  return new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+function localDateString() {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  return new Date().toLocaleDateString('en-CA', { timeZone: tz });
 }
 
 function loadTokenHistory() {
@@ -161,7 +162,7 @@ function updateTokenHistory(currentTotal, today) {
 }
 
 function loadOrUpdateTokenHistory(currentTotal) {
-  const today = londonDateString();
+  const today = localDateString();
   if (Number.isFinite(Number(currentTotal))) {
     return updateTokenHistory(currentTotal, today);
   }

--- a/test-report-2026-02-12-issue-4-dashboard-improvements.md
+++ b/test-report-2026-02-12-issue-4-dashboard-improvements.md
@@ -1,0 +1,34 @@
+# Test Report — webui-nova issue #4 (dashboard improvements)
+
+Date (UTC): 2026-02-12
+Branch: `feat/issue-4-dashboard-improvements`
+
+## Scope verified
+
+1. Session list is AGENT-only
+- Code path: `public/app.js` (`refreshSessions` filters `key.startsWith('agent:')`).
+- Result: PASS
+
+2. SEND flow reliability
+- Non-empty validation added.
+- Guard states for disconnected/no-session.
+- Send button disabled while sending; re-enabled on final/error/disconnect.
+- Result: PASS
+
+3. Reconnect behavior
+- Reconnect button guarded against double-click races.
+- Reconnecting UI state shown while reconnect is in progress.
+- Result: PASS
+
+4. Token usage chart day boundary
+- Day bucket uses local timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) instead of hardcoded London.
+- UI label updated to local-date wording.
+- Result: PASS
+
+5. Obsolete trading panels copy
+- Strings `TOTAL P/L`, `NEXT EXIT`, and `OPEN TRADES` not present in current served UI/server files.
+- Result: PASS
+
+## Notes
+- `node --check server.mjs` passes.
+- No automated UI suite in repo for these flows; verification is code-path + runtime sanity checks.


### PR DESCRIPTION
Closes #4

Changes:
- AGENT-only sessions in selector (stable selection)
- SEND flow hardening (validation, disable while sending, error states)
- Reconnect button: guarded + reconnecting state
- Token usage history uses local timezone day boundary (fix today aggregation)
- Added verification report: `test-report-2026-02-12-issue-4-dashboard-improvements.md`

Commits:
- 4067dfa, 597dc43, 3938a25, 4d474e9
